### PR TITLE
Add Variables and Multi-AZ Support

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,10 +1,10 @@
 provider "aws" {
-  region = "us-east-1"
+  region = var.region
 }
 
 # Create a new VPC
 resource "aws_vpc" "lab_2-vpc" {
-  cidr_block           = "10.0.0.0/16"
+  cidr_block           = var.cidr_block
   enable_dns_hostnames = true
   enable_dns_support   = true
 
@@ -25,8 +25,8 @@ resource "aws_internet_gateway" "lab_2-igw" {
 # Public Subnet
 resource "aws_subnet" "lab_2-public-subnet" {
   vpc_id                  = aws_vpc.lab_2-vpc.id
-  cidr_block              = "10.0.1.0/24"
-  availability_zone       = "us-east-1a"
+  cidr_block              = var.public_subnet_cidr_block
+  availability_zone       = var.availability_zone
   map_public_ip_on_launch = true
 
   tags = {
@@ -57,8 +57,8 @@ resource "aws_route_table_association" "lab_2-public-route-table-association" {
 # Private Subnet
 resource "aws_subnet" "lab_2-private-subnet" {
   vpc_id            = aws_vpc.lab_2-vpc.id
-  cidr_block        = "10.0.2.0/24"
-  availability_zone = "us-east-1a"
+  cidr_block        = var.private_subnet_cidr_block
+  availability_zone = var.availability_zone
 
   tags = {
     Name = "lab_2-private-subnet"

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,29 @@
+variable "region" {
+  description = "The region in which the resources will be created."
+  default     = "us-east-1"
+
+}
+
+variable "availability_zone" {
+  description = "The availability zone in which the resources will be created."
+  default     = "us-east-1a"
+
+}
+
+variable "cidr_block" {
+  description = "The CIDR block for the VPC."
+  default     = "10.0.0.0/16"
+
+}
+
+variable "public_subnet_cidr_block" {
+  description = "The CIDR block for the public subnet."
+  default     = "10.0.1.0/24"
+
+}
+
+variable "private_subnet_cidr_block" {
+  description = "The CIDR block for the private subnet."
+  default     = "10.0.10.0/24"
+
+}


### PR DESCRIPTION
- Refactored configuration to use variables for region, CIDR blocks, and availability zones.
- Added support for multiple availability zones with dynamic public and private subnet creation.
- Introduced `variables.tf` to define input variables for flexibility and scalability.
- Updated route table associations to handle multiple public subnets.

Closes #3